### PR TITLE
Fix formatting for CI lint step

### DIFF
--- a/.sonarlint/connectedMode.json
+++ b/.sonarlint/connectedMode.json
@@ -1,5 +1,5 @@
 {
-    "sonarCloudOrganization": "shatokh",
-    "projectKey": "shatokh_API-test",
-    "region": "EU"
+  "sonarCloudOrganization": "shatokh",
+  "projectKey": "shatokh_API-test",
+  "region": "EU"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-    "sonarlint.connectedMode.project": {
-        "connectionId": "shatokh",
-        "projectKey": "shatokh_API-test"
-    }
+  "sonarlint.connectedMode.project": {
+    "connectionId": "shatokh",
+    "projectKey": "shatokh_API-test"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -93,12 +93,13 @@ You can test the entire API interactively via Swagger UI in your browser.
 - Logger (`morgan`)
 
 ---
+
 ### 🧪 Testing
 
-- **Unit & API tests** with **Vitest**  
-- **HTTP integration** via **Supertest**  
-- **In-memory MongoDB** using **mongodb-memory-server**  
-- **Mocking & assertions** with **Chai** (and built-in Vitest matchers)  
+- **Unit & API tests** with **Vitest**
+- **HTTP integration** via **Supertest**
+- **In-memory MongoDB** using **mongodb-memory-server**
+- **Mocking & assertions** with **Chai** (and built-in Vitest matchers)
 
 ## 🧪 Sample JSON Requests
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,7 +33,7 @@ export default [
       '.env',
       '*.config.js', // eslint and vitest config files
       'tests/setup.js',
-    ]
+    ],
   },
 
   // 6. Base JS/TS rules


### PR DESCRIPTION
## Summary
- run Prettier to fix formatting

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: missing module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852d090480c832fa32f499b78497755