### PR TITLE
Add docker-compose and run tests in Docker

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -11,31 +11,14 @@ on:
 
 jobs:
   api-test:
-    name: Run API Tests
+    name: Run API Tests in Docker
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Cache node modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Build Docker image
+        run: docker build -t auth-api .
 
       - name: Run API tests
-        run: npm run test:api
+        run: docker run --rm --env-file .env.test auth-api npm run test:api

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,31 +11,14 @@ on:
 
 jobs:
   unit-test:
-    name: Run Unit Tests
+    name: Run Unit Tests in Docker
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Cache node modules
-        uses: actions/cache@v3
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-
-
-      - name: Install dependencies
-        run: npm ci
+      - name: Build Docker image
+        run: docker build -t auth-api .
 
       - name: Run unit tests
-        run: npm run test:unit
+        run: docker run --rm --env-file .env.test auth-api npm run test:unit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM node:18
 
 WORKDIR /app
+
 COPY package*.json ./
-RUN npm install
+RUN npm ci
+
 COPY . .
 
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ docker build -t auth-api .
 docker run -p 3000:3000 --env-file .env auth-api
 ```
 
+### Using Docker Compose
+
+```bash
+docker compose up app
+```
+
+Run tests in a container:
+
+```bash
+docker compose run --rm test
+```
+
 ---
 
 ## 🔗 API Endpoints

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    env_file: .env
+    ports:
+      - "3000:3000"
+    command: node server.js
+  test:
+    build: .
+    env_file: .env.test
+    command: npm test


### PR DESCRIPTION
## Summary
- update Dockerfile to install deps with `npm ci`
- add docker-compose.yml to run the app or tests locally
- run unit and API tests inside Docker containers in GitHub Actions
- document Docker Compose workflow

## Testing
- `npm test` *(fails: could not access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68555716c3e0832f9e58132465389278