### PR TITLE
Remove pretest step

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "type": "module",
   "scripts": {
     "start": "node server.js",
-    "pretest": "npm ci",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:api": "vitest run tests/api",


### PR DESCRIPTION
## Summary
- remove the pretest script from package.json

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68555aaccdb8832fbb6d5b67890f5ef3