### PR TITLE
Set NODE_ENV for Docker tests

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -38,4 +38,4 @@ jobs:
         run: npm ci
 
       - name: Run API tests
-        run: npm run test:api
+        run: docker run --rm -e NODE_ENV=test -v ${{ github.workspace }}:/app -w /app node:${{ matrix.node-version }} npm run test:api

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,4 +38,4 @@ jobs:
         run: npm ci
 
       - name: Run unit tests
-        run: npm run test:unit
+        run: docker run --rm -e NODE_ENV=test -v ${{ github.workspace }}:/app -w /app node:${{ matrix.node-version }} npm run test:unit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  test:
+    build: .
+    command: npm test
+    environment:
+      - NODE_ENV=test


### PR DESCRIPTION
## Summary
- add `NODE_ENV=test` environment variable for the `test` service in `docker-compose.yml`
- run API and unit tests inside Docker with `NODE_ENV=test`

## Testing
- `npx lefthook run pre-commit` *(fails: 403 Forbidden)*
- `npm test` *(fails to install dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68555aae5938832f877e6d5e62dc731f