### PR TITLE
Fix container healthcheck

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -72,8 +72,14 @@ jobs:
           severity: 'HIGH,CRITICAL'
 
       - name: Run healthcheck on production image
+        env:
+          MONGO_URI: ${{ secrets.MONGO_URI }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
         run: |
-          docker run -d --rm --name api-test-prod -p 3000:3000 api-test:prod
+          docker run -d --rm --name api-test-prod -p 3000:3000 \
+            -e MONGO_URI="$MONGO_URI" \
+            -e JWT_SECRET="$JWT_SECRET" \
+            api-test:prod
           echo "Waiting for container to become healthy..."
           for i in {1..10}; do
             status=$(docker inspect --format='{{or .State.Health.Status "starting"}}' api-test-prod)

--- a/server.js
+++ b/server.js
@@ -33,6 +33,11 @@ app.use(
   }),
 );
 
+// ✅ Healthcheck endpoint for Docker health checks
+app.get('/health', (req, res) => {
+  res.status(200).json({ status: 'ok' });
+});
+
 // ⚙️ Конфигурация
 const PORT = process.env.PORT || 3000;
 const MONGO_URI = process.env.MONGO_URI;


### PR DESCRIPTION
## Summary
- add `/health` endpoint used by Docker healthcheck
- inject MONGO_URI and JWT_SECRET when running production container in CI

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1663edcc832fbe2e131ba432edfb