### PR TITLE
Update compose for local/CI testing

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -11,11 +11,6 @@ jobs:
     name: Run API Tests, Healthcheck & Trivy Scan
     runs-on: ubuntu-latest
 
-    services:
-      mongo:
-        image: mongo:6
-        ports: ['27017:27017']
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -23,44 +18,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Build builder image with cache
-        run: |
-          docker build \
-            --target builder \
-            -t api-test:builder \
-            --cache-from=type=local,src=/tmp/.buildx-cache \
-            --cache-to=type=local,dest=/tmp/.buildx-cache-new,mode=max \
-            .
-      
-      - name: Move cache
-        if: always() # Этот шаг должен выполняться, даже если предыдущие упали, чтобы сохранить кэш
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      - name: Build images
+        run: docker compose build api-tests server
 
       - name: Run API tests
-        run: |
-          docker run --rm \
-            --network host \
-            --env MONGODB_URI="mongodb://localhost:27017/test-db" \
-            api-test:builder \
-            npm run test:api
+        run: docker compose run --rm api-tests
+
+      - name: Clean up
+        run: docker compose down
 
       - name: Build production image
-        run: |
-          docker build \
-            --target runtime \
-            -t api-test:prod \
-            --cache-from=type=local,src=/tmp/.buildx-cache \
-            .
+        run: docker compose build server
 
       - name: Scan production image for vulnerabilities
         # Закрепляем актуальную версию, например, 0.52.0 на момент написания

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,8 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Build builder image
-        run: docker build --target builder -t api-test:builder .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build unit-test image
+        run: docker compose build unit-tests
 
       - name: Run unit tests
-        run: docker run --rm api-test:builder npm run test:unit
+        run: docker compose run --rm unit-tests

--- a/README.md
+++ b/README.md
@@ -104,8 +104,12 @@ You can test the entire API interactively via Swagger UI in your browser.
 Run tests in a container using **Docker Compose**:
 
 ```bash
-export NODE_ENV=test
-docker compose run --rm test
+# start the API with MongoDB
+docker compose up -d server db
+
+# run unit or API tests
+docker compose run --rm unit-tests
+docker compose run --rm api-tests
 ```
 
 Dependencies are installed during the image build step so each test run is fast.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,48 @@
 version: '3.8'
+
 services:
-  test:
-    build: .
-    command: npm test
+  db:
+    image: mongo:6
+    ports:
+      - "27017:27017"
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.runCommand('ping')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  server:
+    image: api-test:prod
+    build:
+      context: .
+      target: runtime
+    env_file: .env
     environment:
-      - NODE_ENV=test
+      MONGO_URI: mongodb://db:27017/auth-demo
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+
+  unit-tests:
+    image: api-test:builder
+    build:
+      context: .
+      target: builder
+    command: npm run test:unit
+    environment:
+      NODE_ENV: test
+
+  api-tests:
+    image: api-test:builder
+    build:
+      context: .
+      target: builder
+    command: npm run test:api
+    environment:
+      NODE_ENV: test
+      MONGODB_URI: mongodb://db:27017/test-db
+    depends_on:
+      db:
+        condition: service_healthy


### PR DESCRIPTION
## Summary
- allow starting Mongo and API server with docker-compose
- add separate `unit-tests` and `api-tests` services
- update GitHub Actions to use docker-compose
- document how to start server and run tests via compose

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fae58e20832f923c1d74de3eb260