### PR TITLE
Fix mongodb-memory-server binary selection for unit tests

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -16,7 +16,17 @@ beforeAll(async () => {
 
 beforeAll(async () => {
   // Создаём и запускаем in-memory MongoDB только один раз
-  mongoServer = await MongoMemoryServer.create();
+  const systemBinary =
+    process.env.MONGOMS_SYSTEM_BINARY ||
+    (fs.existsSync('/usr/bin/mongod') ? '/usr/bin/mongod' : null);
+  const mongoOptions = systemBinary
+    ? { binary: { systemBinary } }
+    : {
+        binary: {
+          version: process.env.MONGOMS_VERSION || '7.0.12',
+        },
+      };
+  mongoServer = await MongoMemoryServer.create(mongoOptions);
   const uri = mongoServer.getUri();
   try {
     if (mongoose.connection.readyState === 0) {


### PR DESCRIPTION
### Motivation
- Unit tests using `mongodb-memory-server` were failing in CI because the server attempted to download a MongoDB binary that returned HTTP 403 or was not available for the runner platform.
- Prefer using an existing system `mongod` binary when available and allow pinning a fallback version to avoid invalid remote download targets.

### Description
- Update `tests/setup.js` to detect a system `mongod` at `/usr/bin/mongod` or use the `MONGOMS_SYSTEM_BINARY` env var when creating `MongoMemoryServer`.
- Add a fallback option that sets the binary `version` from `MONGOMS_VERSION` or defaults to `7.0.12` when no system binary is available.
- The change prevents uncontrolled remote downloads of an unsupported MongoDB platform/version during test setup.

### Testing
- Pre-commit hooks ran during the change and completed successfully (`lefthook` executed `prettier` and `eslint` with no failures).
- `npm run test:unit` previously failed in this environment due to the `mongodb-memory-server` download being blocked (HTTP 403), and unit tests were not fully re-run after this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ead643544832fab35cbb4d1f520ff)