### PR TITLE
Установить NODE_ENV='test' в setup тестов

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -4,6 +4,8 @@ import mongoose from 'mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import dotenv from 'dotenv';
 
+process.env.NODE_ENV = 'test';
+
 // Определяем файл окружения: .env.test для тестов или .env для локали
 const envFile = fs.existsSync('.env.test') ? '.env.test' : '.env';
 dotenv.config({ path: envFile });


### PR DESCRIPTION
### Motivation
- Предотвратить запуск HTTP-сервера при запуске тестов, так как `server.js` стартует сервер только если `process.env.NODE_ENV !== 'test'`.

### Description
- Добавлена строка `process.env.NODE_ENV = 'test';` в `tests/setup.js` чтобы гарантировать тестовое окружение при инициализации Vitest.

### Testing
- Выполнен `npm test`, но `vitest` отсутствует в окружении и тесты не были выполнены (`sh: 1: vitest: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eb17eb7d8832fa099204b29b85ec2)