### PR TITLE
Refactor Dockerfile stages and add curl to runtime for healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax=docker/dockerfile:1
 
 ####################################
-# Stage 1: builder (support mongodb-memory-server + tests)
+# Stage 1: deps (support mongodb-memory-server + tests)
 ####################################
-FROM node:18-bullseye-slim AS builder
+FROM node:18-bullseye-slim AS deps
 
 # Определяем окружение сборки (production или development)
 ARG NODE_ENV=production
@@ -40,16 +40,23 @@ RUN if [ "$NODE_ENV" = "production" ]; then \
 # Принудительное использование системного бинаря mongod для mongodb-memory-server
 ENV MONGOMS_SYSTEM_BINARY=/usr/bin/mongod
 
-# Копируем весь проект (код и тесты)
 COPY . .
 
 ####################################
-# Stage 2: runtime (production)
+# Stage 2: builder (placeholder for future build steps)
+####################################
+FROM deps AS builder
+
+####################################
+# Stage 3: runtime (production)
 ####################################
 FROM node:18-alpine AS runtime
 
 # Рабочая директория для запуска приложения
 WORKDIR /app
+
+# Устанавливаем curl для healthcheck
+RUN apk add --no-cache curl
 
 # Копируем зависимости и исходники из этапа builder
 COPY --from=builder /app/node_modules ./node_modules


### PR DESCRIPTION
### Motivation
- Align docker stages with compose test targets by introducing a named `deps` stage and keeping a separate `builder` placeholder for future build steps. 
- Ensure the production runtime image includes `curl` so API healthchecks and readiness probes work reliably.

### Description
- Rename the original build stage to `deps` and add `FROM deps AS builder` as a placeholder to decouple dependency installation from later build steps. 
- Install `curl` in the `node:18-alpine` runtime image via `RUN apk add --no-cache curl`. 
- Continue copying dependencies and application files from the builder stage using `COPY --from=builder /app/node_modules ./node_modules` and `COPY --from=builder /app ./`, while preserving `MONGOMS_SYSTEM_BINARY` and the existing `npm ci` logic.

### Testing
- Pre-commit hooks (`lefthook`) ran during the commit and completed successfully, with `eslint` and `prettier` skipped. 
- No unit or integration tests were executed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eb621163c832f8825a8bf66a9d222)