### PR TITLE
Fix Artillery load test workflow in CI

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -41,9 +41,16 @@ jobs:
           '
 
       - name: Run Artillery load test (Cloud)
+        if: ${{ secrets.ARTILLERY_API_KEY != '' }}
         uses: artilleryio/action-cli@7ac990a706d55fc5ffac41bffbbb6b9a709965b6
         with:
-          command: run load-test.yml --record --key ${{ secrets.ARTILLERY_API_KEY }}
+          command: run load-test-ci.yml --record --key ${{ secrets.ARTILLERY_API_KEY }}
+
+      - name: Run Artillery load test (Local)
+        if: ${{ secrets.ARTILLERY_API_KEY == '' }}
+        uses: artilleryio/action-cli@7ac990a706d55fc5ffac41bffbbb6b9a709965b6
+        with:
+          command: run load-test-ci.yml
 
       - name: Stop application
         if: always()

--- a/load-test-ci.yml
+++ b/load-test-ci.yml
@@ -1,0 +1,52 @@
+config:
+  target: "http://localhost:3000"
+  phases:
+    - name: "ramp-up"
+      duration: 60
+      arrivalRate: 1
+      rampTo: 50
+    - name: "steady-state"
+      duration: 120
+      arrivalRate: 50
+    - name: "ramp-down"
+      duration: 30
+      arrivalRate: 50
+      rampTo: 0
+  defaults:
+    headers:
+      Content-Type: "application/json"
+
+scenarios:
+  - name: "Регистрация → Логин → Профиль"
+    flow:
+      - think: 2
+      - post:
+          url: "/api/auth/register"
+          json:
+            email: "user_{{ $processIndex }}_{{ randomInt(1,100000) }}@test.local"
+            password: "Password123!"
+      - think: 1
+      - post:
+          url: "/api/auth/login"
+          json:
+            email: "{{ lastRequest.json.email }}"
+            password: "Password123!"
+          capture:
+            json: "$.token"
+            as: authToken
+      - think: 1
+      - get:
+          url: "/api/auth/me"
+          headers:
+            Authorization: "Bearer {{ authToken }}"
+      - think: 2
+  - name: "Негативный логин"
+    flow:
+      - post:
+          url: "/api/auth/login"
+          json:
+            email: "not_exist_{{ randomInt(1,1000) }}@test.local"
+            password: "WrongPass!"
+          expect:
+            - statusCode: 401
+      - think: 1


### PR DESCRIPTION
### Motivation
- The GitHub Actions job referenced the interactive/cloud Artillery config and attempted Prometheus publishing which can fail in CI when the cloud API key or local pushgateway are not available.
- Provide a CI-friendly Artillery config and make the workflow robust to the presence or absence of `ARTILLERY_API_KEY` to avoid intermittent CI failures.

### Description
- Add a CI-specific Artillery config file `load-test-ci.yml` that omits Prometheus publishing and targets `http://localhost:3000`.
- Update `.github/workflows/load-test.yml` to run Artillery using `load-test-ci.yml` and to conditionally run the cloud-recording command when `secrets.ARTILLERY_API_KEY` is present (`if: ${{ secrets.ARTILLERY_API_KEY != '' }}`) or fall back to a local run when it is not (`if: ${{ secrets.ARTILLERY_API_KEY == '' }}`).
- Change the Artillery `command` to reference `load-test-ci.yml` for both cloud and local executions.

### Testing
- No automated tests were executed because this change only updates CI workflow and config files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69864c5766d4832fa1a6c205c4205d7d)